### PR TITLE
fix(build): Next 14 config cleanup, add eslint-config-prettier and @types/bcryptjs, ensure prisma generate on install

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,4 @@
 module.exports = {
-  extends: ['next', 'next/core-web-vitals', 'prettier'],
+  root: true,
+  extends: ['next/core-web-vitals', 'prettier'],
 };

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,14 @@
+// next.config.js
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true,
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'm.media-amazon.com' }, // IMDb posters
+      { protocol: 'https', hostname: 'img.omdbapi.com' }     // OMDb images (if used)
+    ],
   },
+  eslint: { ignoreDuringBuilds: false },
+  typescript: { ignoreBuildErrors: false },
 };
-
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "shared-watchlist",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@next-auth/prisma-adapter": "^1.0.5",
         "@prisma/client": "^5.7.0",
@@ -23,9 +24,11 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",
+        "@types/bcryptjs": "^2.4.6",
         "autoprefixer": "^10.4.14",
         "eslint": "^8.49.0",
         "eslint-config-next": "14.0.0",
+        "eslint-config-prettier": "^9.1.0",
         "postcss": "^8.4.27",
         "prettier": "^3.0.3",
         "prisma": "^5.7.0",
@@ -1517,6 +1520,13 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3757,6 +3767,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "next lint",
     "test": "vitest",
     "prisma:migrate": "prisma migrate dev",
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts",
+    "postinstall": "prisma generate",
+    "migrate:deploy": "prisma migrate deploy"
   },
   "dependencies": {
     "@prisma/client": "^5.7.0",
@@ -31,9 +33,11 @@
     "autoprefixer": "^10.4.14",
     "eslint": "^8.49.0",
     "eslint-config-next": "14.0.0",
+    "eslint-config-prettier": "^9.1.0",
     "postcss": "^8.4.27",
     "prisma": "^5.7.0",
     "prettier": "^3.0.3",
+    "@types/bcryptjs": "^2.4.6",
     "supertest": "^6.3.3",
     "tailwindcss": "^3.3.3",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
## Summary
- replace experimental Next config with strict mode, remote image patterns, and enforce lint/type checks
- use shared `.eslintrc.cjs` extending `next/core-web-vitals` and `prettier`
- add `eslint-config-prettier` and `@types/bcryptjs`; run `prisma generate` after install

## Testing
- `npm install` *(fails: Error validating field `user` in model `WatchlistCollaborator`...)*
- `npm run lint`
- `npm run build` *(fails: Error: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.)*

------
https://chatgpt.com/codex/tasks/task_e_6899ffc070e08332b0de344cb2c27dfe