### PR TITLE
feat: add email registration

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import bcrypt from 'bcryptjs';
+import prisma from '@/lib/prisma';
+
+export async function POST(req: Request) {
+  try {
+    const { name, email, password } = await req.json();
+
+    // Basic validation
+    if (!email || !password) {
+      return NextResponse.json(
+        { error: 'Email and password are required' },
+        { status: 400 },
+      );
+    }
+
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return NextResponse.json(
+        { error: 'User already exists' },
+        { status: 409 },
+      );
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+
+    await prisma.user.create({
+      data: { email, name: name ?? null, passwordHash },
+    });
+
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (e) {
+    console.error('Register error', e);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,61 @@
 import './globals.css';
+import Link from 'next/link';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { ReactNode } from 'react';
 
 export const metadata = {
   title: 'Shared Watchlist',
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const session = await getServerSession(authOptions);
+
   return (
     <html lang="en">
       <body className="min-h-screen bg-gray-50 text-gray-900">
-        {children}
+        <header className="border-b">
+          <div className="mx-auto flex max-w-5xl items-center justify-between p-4">
+            <Link href="/" className="font-semibold">
+              Shared Watchlist
+            </Link>
+            <nav className="space-x-3">
+              {session ? (
+                <>
+                  <Link href="/profile" className="underline">
+                    Profile
+                  </Link>
+                  <form
+                    action="/api/auth/signout"
+                    method="post"
+                    className="inline"
+                  >
+                    <button className="rounded border px-3 py-1">
+                      Sign out
+                    </button>
+                  </form>
+                </>
+              ) : (
+                <>
+                  <Link href="/signin" className="rounded border px-3 py-1">
+                    Sign in
+                  </Link>
+                  <Link
+                    href="/signup"
+                    className="rounded bg-black px-3 py-1 text-white"
+                  >
+                    Sign up
+                  </Link>
+                </>
+              )}
+            </nav>
+          </div>
+        </header>
+        <main className="mx-auto max-w-5xl p-4">{children}</main>
       </body>
     </html>
   );

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -9,7 +9,11 @@ export default function SignIn() {
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    const res = await signIn('credentials', { redirect: false, email, password });
+    const res = await signIn('credentials', {
+      redirect: false,
+      email,
+      password,
+    });
     if (res?.error) setError(res.error);
     else window.location.href = '/';
   }
@@ -31,9 +35,18 @@ export default function SignIn() {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
-      <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+      <button
+        type="submit"
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
         Sign in
       </button>
+      <p className="mt-4 text-sm">
+        Don’t have an account?{' '}
+        <a className="underline" href="/signup">
+          Sign up
+        </a>
+      </p>
     </form>
   );
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+export default function SignUpPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const name = String(formData.get('name') || '');
+    const email = String(formData.get('email') || '');
+    const password = String(formData.get('password') || '');
+
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, password }),
+    });
+
+    setLoading(false);
+    if (res.ok) {
+      router.push('/signin?registered=1');
+      return;
+    }
+    const data = await res.json().catch(() => ({}));
+    setError(data?.error || 'Failed to register');
+  }
+
+  return (
+    <div className="mx-auto max-w-md p-6">
+      <h1 className="mb-6 text-2xl font-semibold">Create your account</h1>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div className="space-y-1">
+          <label className="block text-sm">Name (optional)</label>
+          <input
+            name="name"
+            type="text"
+            className="w-full rounded border p-2"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm">Email</label>
+          <input
+            name="email"
+            type="email"
+            required
+            className="w-full rounded border p-2"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm">Password</label>
+          <input
+            name="password"
+            type="password"
+            required
+            minLength={6}
+            className="w-full rounded border p-2"
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+        >
+          {loading ? 'Creating…' : 'Sign up'}
+        </button>
+      </form>
+      <p className="mt-4 text-sm">
+        Already have an account?{' '}
+        <Link className="underline" href="/signin">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -14,13 +14,19 @@ export const authOptions: NextAuthOptions = {
         email: { label: 'Email', type: 'text' },
         password: { label: 'Password', type: 'password' },
       },
-      async authorize(credentials) {
-        if (!credentials?.email || !credentials.password) return null;
-        const user = await prisma.user.findUnique({ where: { email: credentials.email } });
+      authorize: async (credentials) => {
+        if (!credentials?.email || !credentials?.password) return null;
+        const user = await prisma.user.findUnique({
+          where: { email: credentials.email },
+        });
         if (!user || !user.passwordHash) return null;
-        const valid = await compare(credentials.password, user.passwordHash);
-        if (!valid) return null;
-        return { id: user.id, name: user.name, email: user.email } as any;
+        const ok = await compare(credentials.password, user.passwordHash);
+        if (!ok) return null;
+        return {
+          id: user.id,
+          name: user.name ?? user.email ?? '',
+          email: user.email ?? '',
+        };
       },
     }),
   ],


### PR DESCRIPTION
## Summary
- add API route to register users with hashed passwords
- provide sign-up page and links in header and sign-in page
- ensure credentials auth checks hashed password

## Testing
- `npx prisma generate`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a09e4d8208332ad7e1a838f4916c7